### PR TITLE
move computeChains to hasher, make concurrency parameter part of Opts,…

### DIFF
--- a/params.go
+++ b/params.go
@@ -13,10 +13,10 @@ type Opts struct {
 
 	// Concurrency specifies the amount of goroutines to use for WOTS
 	// operations. Concurrency follows the following logic for n:
-	//	n > 0: divide chains over n goroutines.
+	//  n > 0: divide chains over n goroutines.
 	//  n == 0: default, use a single goroutine
 	//  n < 0: automatically determine the number of goroutines based on
-	//		   runtime.NumCPU or runtime.GOMAXPROX(-1), whichever is lower.
+	//         runtime.NumCPU or runtime.GOMAXPROX(-1), whichever is lower.
 	Concurrency int
 }
 
@@ -36,7 +36,7 @@ func (o Opts) routines() int {
 		return 1
 	}
 
-	if o.Concurrency >= 0 {
+	if o.Concurrency > 0 {
 		return o.Concurrency
 	}
 

--- a/params.go
+++ b/params.go
@@ -2,6 +2,7 @@ package wotsp
 
 import (
 	"crypto"
+	"runtime"
 )
 
 // Opts groups the parameters required for WOTSP operations. It implements
@@ -9,6 +10,14 @@ import (
 type Opts struct {
 	Mode    Mode
 	Address Address
+
+	// Concurrency specifies the amount of goroutines to use for WOTS
+	// operations. Concurrency follows the following logic for n:
+	//	n > 0: divide chains over n goroutines.
+	//  n == 0: default, use a single goroutine
+	//  n < 0: automatically determine the number of goroutines based on
+	//		   runtime.NumCPU or runtime.GOMAXPROX(-1), whichever is lower.
+	Concurrency int
 }
 
 // Opts should implement crypto.SignerOpts
@@ -18,6 +27,25 @@ var _ crypto.SignerOpts = Opts{}
 // return crypto.SHA256.
 func (Opts) HashFunc() crypto.Hash {
 	return crypto.SHA256
+}
+
+// routines returns the amount of simultanious goroutines to use for WOTS
+// operations, based on Opts.Concurrency.
+func (o Opts) routines() int {
+	if o.Concurrency == 0 {
+		return 1
+	}
+
+	if o.Concurrency >= 0 {
+		return o.Concurrency
+	}
+
+	procs := runtime.GOMAXPROCS(-1)
+	cpus := runtime.NumCPU()
+	if procs > cpus {
+		return cpus
+	}
+	return procs
 }
 
 // params is an internal struct that defines required parameters in WOTS. The

--- a/wots.go
+++ b/wots.go
@@ -7,67 +7,20 @@ Package wotsp implements WOTSP-SHA2_256 as documented in RFC 8391
 package wotsp
 
 import (
-	"sync"
-	"runtime"
 	"crypto/subtle"
 )
 
 // N is a constant used by wotsp.
 const N = 32
 
-// Distributes the chains that must be computed between GOMAXPROCS goroutines.
-//
-// When fromSig is true, in contains a signature and out must be a public key;
-// in this case the routines must complete the signature chains so they use
-// lengths as start indices. If fromSig is false, we are either computing a
-// public key from a private key, or a signature from a private key, so the
-// routines use lengths as the amount of iterations to perform.
-func computeChains(h *hasher, numRoutines int, in, out []byte, lengths []uint8, adrs *Address, p params, fromSig bool) {
-	chainsPerRoutine := (p.l-1)/numRoutines + 1
-
-	// Initialise scratch pad
-	scratch := make([]byte, numRoutines*64)
-
-	wg := new(sync.WaitGroup)
-	for i := 0; i < numRoutines; i++ {
-		// Copy address structure
-		chainAdrs := new(Address)
-		copy(chainAdrs.data[:], adrs.data[:])
-
-		wg.Add(1)
-		go func(nr int, scratch []byte, adrs *Address) {
-			firstChain := nr * chainsPerRoutine
-			lastChain := firstChain + chainsPerRoutine - 1
-
-			// Make sure the last routine ends at the right chain
-			if lastChain >= p.l {
-				lastChain = p.l - 1
-			}
-
-			// Compute the hash chains
-			for j := firstChain; j <= lastChain; j++ {
-				adrs.setChain(uint32(j))
-				if fromSig {
-					h.chain(nr, scratch, in[j*N:(j+1)*N], out[j*N:(j+1)*N], lengths[j], p.w-1-lengths[j], adrs)
-				} else {
-					h.chain(nr, scratch, in[j*N:(j+1)*N], out[j*N:(j+1)*N], 0, lengths[j], adrs)
-				}
-			}
-			wg.Done()
-		}(i, scratch[i*64:(i+1)*64], chainAdrs)
-	}
-
-	wg.Wait()
-}
-
-// Computes the public key that corresponds to the expanded seed.
+// GenPublicKey computes the public key that corresponds to the expanded seed.
 func GenPublicKey(seed, pubSeed []byte, opts Opts) (pubKey []byte, err error) {
 	params, err := opts.Mode.params()
 	if err != nil {
 		return
 	}
 
-	numRoutines := runtime.GOMAXPROCS(-1)
+	numRoutines := opts.routines()
 	h, err := newHasher(seed, pubSeed, opts, numRoutines)
 
 	privKey := h.expandSeed()
@@ -80,7 +33,7 @@ func GenPublicKey(seed, pubSeed []byte, opts Opts) (pubKey []byte, err error) {
 
 	adrs := opts.Address
 	pubKey = make([]byte, params.l*N)
-	computeChains(h, numRoutines, privKey, pubKey, lengths, &adrs, params, false)
+	h.computeChains(numRoutines, privKey, pubKey, lengths, &adrs, params, false)
 
 	return
 }
@@ -93,7 +46,7 @@ func Sign(msg, seed, pubSeed []byte, opts Opts) (sig []byte, err error) {
 		return
 	}
 
-	numRoutines := runtime.GOMAXPROCS(-1)
+	numRoutines := opts.routines()
 	h, err := newHasher(seed, pubSeed, opts, numRoutines)
 	if err != nil {
 		return
@@ -107,20 +60,19 @@ func Sign(msg, seed, pubSeed []byte, opts Opts) (sig []byte, err error) {
 
 	adrs := opts.Address
 	sig = make([]byte, params.l*N)
-	computeChains(h, numRoutines, privKey, sig, lengths, &adrs, params, false)
+	h.computeChains(numRoutines, privKey, sig, lengths, &adrs, params, false)
 
 	return
 }
 
-// Generates a public key from the given signature
+// PublicKeyFromSig generates a public key from the given signature
 func PublicKeyFromSig(sig, msg, pubSeed []byte, opts Opts) (pubKey []byte, err error) {
-	numRoutines := runtime.GOMAXPROCS(-1)
-
 	params, err := opts.Mode.params()
 	if err != nil {
 		return
 	}
 
+	numRoutines := opts.routines()
 	h, err := newHasher(nil, pubSeed, opts, numRoutines)
 	if err != nil {
 		return
@@ -133,19 +85,19 @@ func PublicKeyFromSig(sig, msg, pubSeed []byte, opts Opts) (pubKey []byte, err e
 
 	adrs := opts.Address
 	pubKey = make([]byte, params.l*N)
-	computeChains(h, numRoutines, sig, pubKey, lengths, &adrs, params, true)
+	h.computeChains(numRoutines, sig, pubKey, lengths, &adrs, params, true)
 
 	return
 }
 
 // Verify checks whether the signature is correct for the given message.
-func Verify(pk, sig, msg, pubSeed []byte, opts Opts) (bool, error) {
-	sig, err := PublicKeyFromSig(sig, msg, pubSeed, opts)
-	if err != nil {
-		return false, err
+func Verify(pk, sig, msg, pubSeed []byte, opts Opts) (valid bool, err error) {
+	if sig, err = PublicKeyFromSig(sig, msg, pubSeed, opts); err != nil {
+		return
 	}
 
 	// use subtle.ConstantTimeCompare instead of bytes.Equal to avoid timing
 	// attacks.
-	return subtle.ConstantTimeCompare(pk, sig) == 1, nil
+	valid = subtle.ConstantTimeCompare(pk, sig) == 1
+	return
 }

--- a/wots_test.go
+++ b/wots_test.go
@@ -178,7 +178,7 @@ func BenchmarkPkFromSig(b *testing.B) {
 	opts := Opts{
 		Mode: W16,
 	}
-	
+
 	for i := 0; i < b.N; i++ {
 		PublicKeyFromSig(testdata.Signature, testdata.Message, testdata.PubSeed, opts)
 	}
@@ -213,6 +213,84 @@ func BenchmarkW4PkFromSig(b *testing.B) {
 
 	opts := Opts{
 		Mode: W4,
+	}
+
+	for i := 0; i < b.N; i++ {
+		PublicKeyFromSig(testdata.SignatureW4, testdata.Message, testdata.PubSeed, opts)
+	}
+}
+
+func BenchmarkConcurrentGenPublicKey(b *testing.B) {
+	b.ReportAllocs()
+
+	opts := Opts{
+		Mode:        W16,
+		Concurrency: -1,
+	}
+
+	for i := 0; i < b.N; i++ {
+		GenPublicKey(testdata.Seed, testdata.PubSeed, opts)
+	}
+}
+
+func BenchmarkConcurrentSign(b *testing.B) {
+	b.ReportAllocs()
+
+	opts := Opts{
+		Mode:        W16,
+		Concurrency: -1,
+	}
+
+	for i := 0; i < b.N; i++ {
+		Sign(testdata.Message, testdata.Seed, testdata.PubSeed, opts)
+	}
+}
+
+func BenchmarkConcurrentPkFromSig(b *testing.B) {
+	b.ReportAllocs()
+
+	opts := Opts{
+		Mode:        W16,
+		Concurrency: -1,
+	}
+
+	for i := 0; i < b.N; i++ {
+		PublicKeyFromSig(testdata.Signature, testdata.Message, testdata.PubSeed, opts)
+	}
+}
+
+func BenchmarkConcurrentW4GenPublicKey(b *testing.B) {
+	b.ReportAllocs()
+
+	opts := Opts{
+		Mode:        W4,
+		Concurrency: -1,
+	}
+
+	for i := 0; i < b.N; i++ {
+		GenPublicKey(testdata.Seed, testdata.PubSeed, opts)
+	}
+}
+
+func BenchmarkConcurrentW4Sign(b *testing.B) {
+	b.ReportAllocs()
+
+	opts := Opts{
+		Mode:        W4,
+		Concurrency: -1,
+	}
+
+	for i := 0; i < b.N; i++ {
+		Sign(testdata.Message, testdata.Seed, testdata.PubSeed, opts)
+	}
+}
+
+func BenchmarkConcurrentW4PkFromSig(b *testing.B) {
+	b.ReportAllocs()
+
+	opts := Opts{
+		Mode:        W4,
+		Concurrency: -1,
 	}
 
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
… switch from sync.WaitGroup so completion channel.

Moved computeChains to be a method of hasher, as it seems like a logical fit.

Replaced the implicit GOMAXPROCS use for concurrency with a parameter in Opts. Passing default Opts does not change original behaviour (still uses a single goroutine). The logic behind selection of the number of goroutines used for computations is included in the comments of the parameter.

Removed the manual copying Address data from slice to slice within the goroutines, instead passing the variable by value which automatically copies the data as Address is a fixed-size type.

Switched out the sync.WaitGroup for a completion channel. Other than being a bit more idiomatic, It seems to have an ever-so-slight influence on performance, though these measurements should be taken with a few grains of salt:

```
Waitgroup implementation:

(run 1)
BenchmarkGenPublicKey-12                            1000           1205935 ns/op            5584 B/op         15 allocs/op
BenchmarkSign-12                                    2000            592959 ns/op            5701 B/op         17 allocs/op
BenchmarkPkFromSig-12                               2000            616200 ns/op            3235 B/op         14 allocs/op
BenchmarkW4GenPublicKey-12                          2000            531721 ns/op           10768 B/op         15 allocs/op
BenchmarkW4Sign-12                                  5000            301727 ns/op           11013 B/op         17 allocs/op
BenchmarkW4PkFromSig-12                             5000            256654 ns/op            5989 B/op         14 allocs/op
BenchmarkConcurrentGenPublicKey-12                  3000            434214 ns/op            8480 B/op         37 allocs/op
BenchmarkConcurrentSign-12                          5000            366515 ns/op            8595 B/op         39 allocs/op
BenchmarkConcurrentPkFromSig-12                     3000            350751 ns/op            6131 B/op         36 allocs/op
BenchmarkConcurrentW4GenPublicKey-12                5000            362475 ns/op           13664 B/op         37 allocs/op
BenchmarkConcurrentW4Sign-12                        5000            291083 ns/op           13909 B/op         39 allocs/op
BenchmarkConcurrentW4PkFromSig-12                  10000            205041 ns/op            8885 B/op         36 allocs/op


Completion channel implementation:

(run 1)
BenchmarkGenPublicKey-12                            2000           1179505 ns/op            5664 B/op         15 allocs/op
BenchmarkSign-12                                    2000            593961 ns/op            5780 B/op         17 allocs/op
BenchmarkPkFromSig-12                               2000            602155 ns/op            3315 B/op         14 allocs/op
BenchmarkW4GenPublicKey-12                          3000            527479 ns/op           10849 B/op         15 allocs/op
BenchmarkW4Sign-12                                  5000            303341 ns/op           11093 B/op         17 allocs/op
BenchmarkW4PkFromSig-12                             5000            257788 ns/op            6069 B/op         14 allocs/op
BenchmarkConcurrentGenPublicKey-12                  3000            432230 ns/op            8582 B/op         37 allocs/op
BenchmarkConcurrentSign-12                          3000            361856 ns/op            8675 B/op         39 allocs/op
BenchmarkConcurrentPkFromSig-12                     5000            318842 ns/op            6211 B/op         36 allocs/op
BenchmarkConcurrentW4GenPublicKey-12                5000            350981 ns/op           13748 B/op         37 allocs/op
BenchmarkConcurrentW4Sign-12                        5000            275830 ns/op           13989 B/op         39 allocs/op
BenchmarkConcurrentW4PkFromSig-12                  10000            193109 ns/op            8965 B/op         36 allocs/op

(run 2)
BenchmarkGenPublicKey-12                            1000           1223681 ns/op            5664 B/op         15 allocs/op
BenchmarkSign-12                                    2000            573825 ns/op            5779 B/op         17 allocs/op
BenchmarkPkFromSig-12                               2000            595281 ns/op            3315 B/op         14 allocs/op
BenchmarkW4GenPublicKey-12                          3000            536396 ns/op           10848 B/op         15 allocs/op
BenchmarkW4Sign-12                                  5000            299896 ns/op           11094 B/op         17 allocs/op
BenchmarkW4PkFromSig-12                             5000            253187 ns/op            6069 B/op         14 allocs/op
BenchmarkConcurrentGenPublicKey-12                  3000            439728 ns/op            8597 B/op         37 allocs/op
BenchmarkConcurrentSign-12                          3000            358041 ns/op            8675 B/op         39 allocs/op
BenchmarkConcurrentPkFromSig-12                     5000            329028 ns/op            6211 B/op         36 allocs/op
BenchmarkConcurrentW4GenPublicKey-12                5000            346738 ns/op           13744 B/op         37 allocs/op
BenchmarkConcurrentW4Sign-12                        5000            281884 ns/op           13989 B/op         39 allocs/op
BenchmarkConcurrentW4PkFromSig-12                  10000            192535 ns/op            8965 B/op         36 allocs/op
```