### PR TITLE
Support different hash functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/lentus/wotsp.svg?branch=concurrent)](https://travis-ci.org/lentus/wotsp) [![Go Report Card](https://goreportcard.com/badge/github.com/lentus/wotsp)](https://goreportcard.com/report/github.com/lentus/wotsp)
+[![Build Status](https://travis-ci.org/lentus/wotsp.svg?branch=concurrent)](https://travis-ci.org/lentus/wotsp) [![GoDoc](https://godoc.org/github.com/lentus/wotsp?status.svg)](https://godoc.org/github.com/lentus/wotsp) [![Go Report Card](https://goreportcard.com/badge/github.com/lentus/wotsp)](https://goreportcard.com/report/github.com/lentus/wotsp)
 
 # W-OTS+
 A Go implementation of the Winternitz OTS (W-OTS+), as described in [RFC8391](https://datatracker.ietf.org/doc/rfc8391/).

--- a/wots_test.go
+++ b/wots_test.go
@@ -7,6 +7,11 @@ import (
 	"testing"
 
 	"github.com/lentus/wotsp/testdata"
+
+	// ensure our crypto is available. This is part of the tests, but not of the
+	// library itself, to avoid including more packages than the library's user
+	// will actually need.
+	_ "crypto/sha256"
 )
 
 // noerr is a helper that triggers t.Fatal[f] if the error is non-nil.


### PR DESCRIPTION
As discussed, a small set of hash functions that can be supported by precomputations are now allowed as options for `Opts.Hash`. If none is provided (defaults to `crypto.Hash(0)`) `hasher` will use `sha256` by default.